### PR TITLE
Don't delete 'pljava' project from within image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,17 @@ RUN echo deb http://ftp.us.debian.org/debian jessie main >> /etc/apt/sources.lis
     apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install g++ maven && \
     apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install postgresql-server-dev-9.4 libpq-dev && \
     apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install libecpg-dev libkrb5-dev && \
-    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install oracle-java8-installer && \
+    apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install oracle-java8-installer libssl-dev && \
     export PGXS=/usr/lib/postgresql/9.4/lib/pgxs/src/makefiles/pgxs.mk && \
     cd pljava && \
-    mvn clean install && \
+    git checkout tags/V1_5_0 && \
+    mvn -Pwnosign clean install && \
     java -jar /pljava/pljava-packaging/target/pljava-pg9.4-amd64-Linux-gpp.jar && \
     cd ../ && \
-    cp pljava/pljava-examples/target/*.jar / && \
-    /bin/bash -c 'for file in *.jar ; do mv $file pljava-examples.jar ; done' && \
-    apt-get -y remove --purge --auto-remove git ca-certificates g++ maven postgresql-server-dev-9.4 libpq-dev libecpg-dev libkrb5-dev oracle-java8-installer && \
+    apt-get -y remove --purge --auto-remove git ca-certificates g++ maven postgresql-server-dev-9.4 libpq-dev libecpg-dev libkrb5-dev oracle-java8-installer libssl-dev && \
     apt-get clean && apt-get update && apt-get --fix-missing -y --force-yes --no-install-recommends install openjdk-8-jdk-headless && \
     apt-get -y clean autoclean autoremove && \
-    rm -rf ~/.m2 && rm -rf pljava/ /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf ~/.m2 /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD /docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 

--- a/docker-entrypoint-initdb.d/01_init_pljava.sql
+++ b/docker-entrypoint-initdb.d/01_init_pljava.sql
@@ -2,7 +2,7 @@ SET pljava.libjvm_location TO '/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/s
 ALTER DATABASE postgres SET pljava.libjvm_location FROM CURRENT;
 ALTER USER postgres SET SEARCH_PATH TO public,sqlj;
 CREATE EXTENSION pljava;
-SELECT sqlj.install_jar('file:///pljava-examples.jar', 'examples', true);
+SELECT sqlj.install_jar('file:///pljava/pljava-examples/target/pljava-examples-1.5.0.jar', 'examples', true);
 SHOW search_path;
 SELECT sqlj.get_classpath('javatest');
 SELECT sqlj.set_classpath('javatest', 'examples');


### PR DESCRIPTION
Ensure libssl-dev is on path to build pljava (we remove when done).
Build pljava with -Pwnosign to avoid gcc warnings aboout signed-ness conversion.